### PR TITLE
Remove explicit default values from to_json

### DIFF
--- a/data/get_hymns.py
+++ b/data/get_hymns.py
@@ -20,4 +20,4 @@ hymns = pd.read_csv(url)
 hymn_titles = hymns['displayTitle']
 
 # export as .json
-hymn_titles.to_json("hymns.json", compression='infer', index=False)
+hymn_titles.to_json("hymns.json")


### PR DESCRIPTION
This change removes two keyword arguments from to_json that are not used meaningfully. They are being set to their default values and these values do not appear to be relevant in our usage.