### PR TITLE
Combine td and th styles

### DIFF
--- a/style.css
+++ b/style.css
@@ -39,21 +39,14 @@ tbody tr:hover {
 /* Alignment and style */
 td,
 th {
-  text-align: left;
+  padding: 12px 8px;
   border: none;
-  padding-right: 8px;
-  padding-left: 8px;
+  vertical-align: top;
+  text-align: left;
 }
 
 th {
-  text-transform: uppercase;
+  padding-block: 1px;
   vertical-align: bottom;
-  padding-top: 1px;
-  padding-bottom: 1px;
-}
-
-td {
-  vertical-align: top;
-  padding-top: 12px;
-  padding-bottom: 12px;
+  text-transform: uppercase;
 }


### PR DESCRIPTION
This is a minor change that combines a few styles shared between td and th elements. This adds base styles to both elements and then overrides only the 3 items that make the th unique (uppercase, bottom-aligned, and reduced top/bottom padding).

From my point of view, this makes it easier to see which styles are shared and should also simplify future updates to the styles of these elements.

This should not change the look of the page in any way if I've implemented it as I intended.