### PR TITLE
Add clean task to makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -19,3 +19,6 @@ lint-py:
 
 lint-py-fix:
 	pipx run --spec ruff==0.13.3 ruff check . --fix
+
+clean:
+	rm -rf .ruff_cache


### PR DESCRIPTION
The `lint` task currently leaves a .ruff_cache directory behind. This change adds a `clean` task to the makefile that will remove it.