### PR TITLE
Convert qu parameter to Dictionary

### DIFF
--- a/data/get_hymns.py
+++ b/data/get_hymns.py
@@ -7,13 +7,20 @@ import numpy as np
 base_url = "https://hymnary.org/search"
 
 params = {
-    "qu": "textLanguages:english denominations:church of god media:text "
-    "textClassification:textispublicdomain tuneClassification:tuneispublicdomain in:texts",
+    "qu": {
+        "textLanguages": "english",
+        "denominations": "church of god",
+        "media": "text",
+        "textClassification": "textispublicdomain",
+        "tuneClassification": "tuneispublicdomain",
+        "in": "texts",
+    },
     "sort": "totalInstances",
     "export": "csv",
     "limit": 100
 }
 
+params["qu"] = " ".join([f"{k}:{v}" for k, v in params["qu"].items()])
 query_string = urlencode(params)
 url = f"{base_url}?{query_string}"
 


### PR DESCRIPTION
This change splits the long string used to pass the `qu` parameter into a dictionary. This eliminates a long line and makes it more clear that the `qu` param is itself a dictionary of parameters, eliminating potential for typos or formatting errors in the query.