### PR TITLE
Add status badges

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 [![Lint](https://github.com/jncraton/psalm-pilot/actions/workflows/lint.yml/badge.svg)](https://github.com/jncraton/psalm-pilot/actions/workflows/lint.yml)
 [![Run Tests](https://github.com/jncraton/psalm-pilot/actions/workflows/tests.yml/badge.svg)](https://github.com/jncraton/psalm-pilot/actions/workflows/tests.yml)
-[![Deploy Status](https://github.com/jncraton/psalm-pilot/actions/workflows/pages.yml/badge.svg)](https://github.com/jncraton/psalm-pilot/actions/workflows/pages.yml)
+[![Deploy To Pages](https://github.com/jncraton/psalm-pilot/actions/workflows/pages.yml/badge.svg)](https://github.com/jncraton/psalm-pilot/actions/workflows/pages.yml)
 
 Hymn recommendation system
 


### PR DESCRIPTION
Add status badges for the three different Github action jobs we have right now: lint, test, and deploy