### PR TITLE
Add caption to hymn table

### DIFF
--- a/style.css
+++ b/style.css
@@ -22,6 +22,10 @@ table {
   margin-top: 1rem;
 }
 
+caption {
+  font-size: 125%;
+}
+
 /*Header row*/
 thead {
   border-bottom: 2px solid #333;
@@ -37,15 +41,18 @@ tbody tr:hover {
 /*Cellstyle*/
 /* Alignment and style */
 td,
-th {
+th,
+caption {
   padding: 12px 8px;
   border: none;
   vertical-align: top;
   text-align: left;
 }
 
-th {
+th,
+caption {
   padding-block: 1px;
   vertical-align: bottom;
   text-transform: uppercase;
+  font-weight: bold;
 }

--- a/templates/index.jinja
+++ b/templates/index.jinja
@@ -14,10 +14,11 @@
     </header>
     <main>
       <table>
+        <caption>Hymns</caption>
         <thead>
           <tr>
-            <th>Hymn Title</th>
-            <th>Hymn Author</th>
+            <th>Title</th>
+            <th>Author</th>
           </tr>
         </thead>
         <tbody>


### PR DESCRIPTION
This change adds a `caption` to the hymns table. This clearly describes what the table contains, and makes it sensible to remove the `hymn` prefix from each column header.