### PR TITLE
Update the requirements for the data venv

### DIFF
--- a/data/requirements.txt
+++ b/data/requirements.txt
@@ -1,6 +1,11 @@
-﻿numpy==2.3.3
+certifi==2025.10.5
+charset-normalizer==3.4.4
+idna==3.11
+numpy==2.3.3
 pandas==2.3.3
 python-dateutil==2.9.0.post0
 pytz==2025.2
+requests==2.32.5
 six==1.17.0
 tzdata==2025.2
+urllib3==2.5.0


### PR DESCRIPTION
Add `requests` dependency which was added in https://github.com/jncraton/psalm-pilot/pull/75. I manually encoded it to UTF 8 this time with notepad so I do not think the previous issue will come up. I am a little confused though as to why its not showing up as binary anymore but it still works locally for me