### PR TITLE
Default to `build` task in makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,3 +1,4 @@
+all: build
 
 .PHONY: lint lint-fix lint-js lint-py lint-py-fix install build clean clean-cache clean-build test
 


### PR DESCRIPTION
This change adds `build` as the default make task. This is a minor change that allows running `make` alone to produce all of the HTML pages necessary to deploy the application.