### PR TITLE
Link to Hymnary on each hymn page

### DIFF
--- a/templates/hymn.jinja
+++ b/templates/hymn.jinja
@@ -14,6 +14,8 @@
       <dd>{{ hymn.popularity }}%</dd>
       <dt>Lyrics</dt>
       <dd><blockquote>{{ hymn.text }}</blockquote></dd>
+      <dt>More Information</dt>
+      <dd><a href="https://hymnary.org/text/{{ hymn.titleId }}">hymnary.org</a></dd>
     </dl> 
   </div>
 {% endblock %}

--- a/tests/test_hymn_pages.py
+++ b/tests/test_hymn_pages.py
@@ -1,5 +1,6 @@
 from playwright.sync_api import Page, expect
 from pathlib import Path
+import re
 
 
 def test_song_lyrics(page: Page, hymn_data: list):
@@ -15,3 +16,12 @@ def test_song_lyrics(page: Page, hymn_data: list):
         
         # Confirm the hymn lyrics on the new page
         expect(page.locator("blockquote")).to_contain_text(hymn_lyrics)
+
+def test_hymn_link(page: Page, hymn_data: list):
+    for hymn in hymn_data[:2] + hymn_data[-2:]:
+        page.goto(Path(f"hymns/{hymn['titleId']}.html").resolve().as_uri())
+
+        # Confirm 200 status on link click
+        with page.expect_response(re.compile(r"hymnary.org")) as response_info:
+            page.get_by_text("hymnary.org").click()
+        assert response_info.value.status == 200


### PR DESCRIPTION
This change adds a backlink to Hymnary on each hymn page. This provides a mechanism for users to see more details about a hymn, and should also provide benefits during development.